### PR TITLE
Output the project root.

### DIFF
--- a/lib/simplecov-json.rb
+++ b/lib/simplecov-json.rb
@@ -7,6 +7,7 @@ class SimpleCov::Formatter::JSONFormatter
     data = {}
     data[:timestamp] = result.created_at.to_i
     data[:command_name] = result.command_name
+    data[:project_root] = SimpleCov.root
     data[:files] = []
     result.files.each do |sourceFile|
       next unless result.filenames.include? sourceFile.filename

--- a/test/test_simplecov_json.rb
+++ b/test/test_simplecov_json.rb
@@ -51,7 +51,8 @@ class TestSimpleCovHtml < Test::Unit::TestCase
     # lines_of_code
     assert_equal(formatter.format(result), {
       'timestamp' => created_at.to_i, 
-      'command_name' => 'RSpec', 
+      'command_name' => 'RSpec',
+      'project_root' => SimpleCov.root,
       'files' => [
         {'filename' => '/lib/foo.rb',
           'covered_percent' => 50.0,


### PR DESCRIPTION
# What? Why?

I'm writing a tool that does some post-processing of simplecov.json.
In order to post-process simplecov.json files and convert absolute paths
to relative paths, it's necessary to know the project root directory.
This commit adds a project_root attribute to the output.

# How was it tested?

I added to the spec.

I also ran it on anther project and inspected the output.
