### PR TITLE
Update for simplecov changes

### DIFF
--- a/lib/simplecov-json.rb
+++ b/lib/simplecov-json.rb
@@ -13,7 +13,7 @@ class SimpleCov::Formatter::JSONFormatter
       data[:files] << {
         filename: sourceFile.filename,
         covered_percent: sourceFile.covered_percent,
-        coverage: sourceFile.coverage,
+        coverage: sourceFile.coverage_data,
         covered_strength: sourceFile.covered_strength.nan? ? 0.0 : sourceFile.covered_strength, 
         covered_lines: sourceFile.covered_lines.count, 
         lines_of_code: sourceFile.lines_of_code, 

--- a/simplecov-json.gemspec
+++ b/simplecov-json.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "simplecov-json"
-  s.version     = '0.2'
+  s.version     = '0.2.1'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Vicent Llongo"]
   s.email       = ["villosil@gmail.com"]


### PR DESCRIPTION
SimpleCov recently changed their attribute from `coverage` to `coverage_data`:

https://github.com/colszowka/simplecov/commit/6e7a9ab3fa2c03ee86930596139270d822e2cc77#diff-46af4f57a15019b45e7bb2e9c2f38c53

We need to update as well.